### PR TITLE
Add GitHub Actions to run linting and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,16 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Download MediaWiki test dependencies
+      run: |
+        mkdir -p tests/mediawiki/includes/cache
+        mkdir -p tests/mediawiki/includes/libs/objectcache
+        wget -O tests/mediawiki/includes/libs/objectcache/BagOStuff.php https://raw.githubusercontent.com/wikimedia/mediawiki/REL1_30/includes/libs/objectcache/BagOStuff.php
+        wget -O tests/mediawiki/includes/libs/objectcache/HashBagOStuff.php https://raw.githubusercontent.com/wikimedia/mediawiki/REL1_30/includes/libs/objectcache/HashBagOStuff.php
+        wget -O tests/mediawiki/includes/cache/IExpiringStore.php https://raw.githubusercontent.com/wikimedia/mediawiki/REL1_30/includes/cache/IExpiringStore.php
+        wget -O tests/mediawiki/includes/libs/ScopedCallback.php https://raw.githubusercontent.com/wikimedia/mediawiki/REL1_30/includes/libs/ScopedCallback.php
+        wget -O tests/mediawiki/includes/libs/WaitConditionLoop.php https://raw.githubusercontent.com/wikimedia/mediawiki/REL1_30/includes/libs/WaitConditionLoop.php
+
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: ['5.6', '7.0']
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-version }}
+
+    - name: Install dependencies
+      run: composer install
+
+    - name: Run tests
+      run: composer ci

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     ],
     "ci": [
       "@lint",
-      "phpunit --coverage-clover=coverage.clover"
+      "phpunit src --coverage-clover=coverage.clover"
     ]
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,18 +20,15 @@
   },
   "scripts": {
     "lint": "parallel-lint . --exclude vendor",
-    "sniff": "phpcs -ps src",
     "phpunit": "phpunit",
     "phpunit-unit": "phpunit --testsuite unit",
     "phpunit-integration": "phpunit --testsuite integration",
     "test": [
       "@lint",
-      "@sniff",
       "@phpunit"
     ],
     "ci": [
       "@lint",
-      "@sniff",
       "phpunit --coverage-clover=coverage.clover"
     ]
   },

--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,8 @@
     "jakub-onderka/php-parallel-lint": "^0.9.2",
     "mediawiki/mediawiki-codesniffer": "^0.7.2",
     "phpunit/phpunit": "~4.8.0|~5.3.0",
-    "cache/integration-tests": "~0.9.1",
-    "mediawiki/mediawiki": "dev-REL1_30 as 1.30.x-dev"
+    "cache/integration-tests": "~0.9.1"
   },
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/wikimedia/mediawiki"
-    }
-  ],
   "scripts": {
     "lint": "parallel-lint . --exclude vendor",
     "phpunit": "phpunit",
@@ -49,7 +42,11 @@
       "Mediawiki\\Api\\Test\\": ["tests/integration", "tests/unit"]
     },
     "files": [
-      "vendor/mediawiki/mediawiki/includes/libs/objectcache/HashBagOStuff.php"
+      "tests/mediawiki/includes/cache/IExpiringStore.php",
+      "tests/mediawiki/includes/libs/ScopedCallback.php",
+      "tests/mediawiki/includes/libs/WaitConditionLoop.php",
+      "tests/mediawiki/includes/libs/objectcache/BagOStuff.php",
+      "tests/mediawiki/includes/libs/objectcache/HashBagOStuff.php"
     ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "lint": "parallel-lint . --exclude vendor",
-    "sniff": "phpcs -ps",
+    "sniff": "phpcs -ps src",
     "phpunit": "phpunit",
     "phpunit-unit": "phpunit --testsuite unit",
     "phpunit-integration": "phpunit --testsuite integration",

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,15 @@
     "jakub-onderka/php-parallel-lint": "^0.9.2",
     "mediawiki/mediawiki-codesniffer": "^0.7.2",
     "phpunit/phpunit": "~4.8.0|~5.3.0",
-    "cache/integration-tests": "~0.9.1"
+    "cache/integration-tests": "~0.9.1",
+    "mediawiki/mediawiki": "dev-REL1_30 as 1.30.x-dev"
   },
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/wikimedia/mediawiki"
+    }
+  ],
   "scripts": {
     "lint": "parallel-lint . --exclude vendor",
     "phpunit": "phpunit",
@@ -29,7 +36,7 @@
     ],
     "ci": [
       "@lint",
-      "phpunit src --coverage-clover=coverage.clover"
+      "phpunit"
     ]
   },
   "autoload": {
@@ -40,6 +47,9 @@
   "autoload-dev": {
     "psr-4": {
       "Mediawiki\\Api\\Test\\": ["tests/integration", "tests/unit"]
-    }
+    },
+    "files": [
+      "vendor/mediawiki/mediawiki/includes/libs/objectcache/HashBagOStuff.php"
+    ]
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="psr-6-mediawiki-bagostuff-adapter Test Suite">
+            <directory>src</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+            <exclude>
+                <directory>src/vendor</directory>
+                <file>src/BagOStuffPsrCacheTest.php</file>
+            </exclude>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="coverage-clover" target="coverage.clover"/>
+    </logging>
+</phpunit>


### PR DESCRIPTION
This commit adds a GitHub Actions workflow to automatically run linting and tests on every push and pull request.

The workflow runs on a matrix of PHP versions (5.6 and 7.0) to ensure compatibility. It uses the 'ci' script from composer.json to run the checks.